### PR TITLE
Update Icon to FontAwesome v5.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "flarum-extension": {
             "title": "Likes",
             "icon": {
-                "name": "thumbs-o-up",
+                "name": "far fa-thumbs-up",
                 "backgroundColor": "#3A649D",
                 "color": "#fff"
             }

--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -5,7 +5,7 @@ import PermissionGrid from 'flarum/components/PermissionGrid';
 app.initializers.add('flarum-likes', () => {
   extend(PermissionGrid.prototype, 'replyItems', items => {
     items.add('likePosts', {
-      icon: 'thumbs-o-up',
+      icon: 'far fa-thumbs-up',
       label: app.translator.trans('flarum-likes.admin.permissions.like_posts_label'),
       permission: 'discussion.likePosts'
     });

--- a/js/forum/src/addLikesList.js
+++ b/js/forum/src/addLikesList.js
@@ -46,7 +46,7 @@ export default function() {
 
       items.add('liked', (
         <div className="Post-likedBy">
-          {icon('thumbs-o-up')}
+          {icon('far fa-thumbs-up')}
           {app.translator.transChoice('flarum-likes.forum.post.liked_by' + (likes[0] === app.session.user ? '_self' : '') + '_text', names.length, {
             count: names.length,
             users: punctuateSeries(names)

--- a/js/forum/src/components/PostLikedNotification.js
+++ b/js/forum/src/components/PostLikedNotification.js
@@ -4,7 +4,7 @@ import punctuateSeries from 'flarum/helpers/punctuateSeries';
 
 export default class PostLikedNotification extends Notification {
   icon() {
-    return 'thumbs-o-up';
+    return 'far fa-thumbs-up';
   }
 
   href() {

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -20,7 +20,7 @@ app.initializers.add('flarum-likes', () => {
   extend(NotificationGrid.prototype, 'notificationTypes', function (items) {
     items.add('postLiked', {
       name: 'postLiked',
-      icon: 'thumbs-o-up',
+      icon: 'far fa-thumbs-up',
       label: app.translator.trans('flarum-likes.forum.settings.notify_post_liked_label')
     });
   });


### PR DESCRIPTION
This PR will update outdated icon names to match with current version of FontAwesome (v5.0.6).

But, before this can be merged, here's a todo:
- [x] Wait for flarum/core#1372 to be merged