### PR TITLE
Fix notifications for [deleted] users

### DIFF
--- a/src/Listener/SendNotificationWhenPostIsLiked.php
+++ b/src/Listener/SendNotificationWhenPostIsLiked.php
@@ -30,7 +30,7 @@ class SendNotificationWhenPostIsLiked
 
     public function handle(PostWasLiked $event)
     {
-        if ($event->post->user->id != $event->user->id) {
+        if ($event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 [$event->post->user]

--- a/src/Listener/SendNotificationWhenPostIsUnliked.php
+++ b/src/Listener/SendNotificationWhenPostIsUnliked.php
@@ -30,7 +30,7 @@ class SendNotificationWhenPostIsUnliked
 
     public function handle(PostWasUnliked $event)
     {
-        if ($event->post->user->id != $event->user->id) {
+        if ($event->post->user && $event->post->user->id != $event->user->id) {
             $this->notifications->sync(
                 new PostLikedBlueprint($event->post, $event->user),
                 []


### PR DESCRIPTION
Same issue with https://github.com/FriendsOfFlarum/reactions/pull/19

Currently when one likes or unlikes a `[deleted]` user's post, it will throw an exception. This should fix it.